### PR TITLE
Updated the gcode URLs to match the current files in Printr-Config

### DIFF
--- a/pb-firmware-update.sh
+++ b/pb-firmware-update.sh
@@ -121,19 +121,19 @@ function normal_update() {
 
     case ${modelResponse[2]} in
     Junior)
-        CONFIG='https://raw.github.com/Printrbot/Printr-Configs/master/Config-Jr.gcode'
+        CONFIG='https://raw.github.com/Printrbot/Printr-Configs/master/Config-Jr-v1.gcode'
         ;;
     LC/Original)
-        CONFIG='https://raw.github.com/Printrbot/Printr-Configs/master/Config-LC.gcode'
+        CONFIG='https://raw.github.com/Printrbot/Printr-Configs/master/Config-LC-v1.gcode'
         ;;
     Plus-v2)
         CONFIG='https://raw.github.com/Printrbot/Printr-Configs/master/Config-Plus-v2.1.gcode'
         ;;
     Plus-v1)
-        CONFIG='https://raw.github.com/Printrbot/Printr-Configs/master/Config-Plus.gcode'
+        CONFIG='https://raw.github.com/Printrbot/Printr-Configs/master/Config-Plus-1404.gcode'
         ;;
     Simple)
-        CONFIG='https://raw.github.com/Printrbot/Printr-Configs/master/Config-Simple.gcode'
+        CONFIG='https://raw.github.com/Printrbot/Printr-Configs/master/Config-Simple-v1.gcode'
         ;;
     *)
         error_box "An unexpected error occurred" 


### PR DESCRIPTION
The current version of the FirmwareUpdatr uses old URLs for the Printr-Config gcode files. There's probably a better way to ensure that the most recent version is retrieved, but for now this update points the script to the correct URLs.
